### PR TITLE
Added docker standalone support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM confluentinc/cp-kafka-connect-base:5.3.1
+
+COPY ./config/* /kafka-connect-reddit/
+COPY dockerStart.sh /kafka-connect-reddit/
+COPY target/components/packages/* /kafka-connect-reddit/install/
+
+ENTRYPOINT ["/kafka-connect-reddit/dockerStart.sh"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,37 @@ mvn package
 and then copying and unzipping the zip archive generated in the `target/components/packages`
 directory onto the plugin path or classpath for your Kafka Connect worker(s).
 
+## Running standalone in docker
+
+To run this in standalone-mode via a docker container. (This brings up the environment + the connect-standalone):
+
+```bash
+#Build the project 
+mvn clean package
+
+# Build the docker container 
+docker build -t redditconnector .
+
+# Run 
+docker run --env-file reddit.env -it redditconnector
+
+```
+
+The environment file that was used looks like this: (To configure the subreddit, comment location, and where your broker can be reached)
+
+```bash
+SUBREDDIT=chicagohelicopters
+COMMENTS_SUBREDDIT=chicagohelicopters
+KAFKA_SERVER=<kafka hostname>:9092
+```
+
+Note: Change the kafka host name. If the variable in the file or docker run arguements is not present then it will default to the following values:
+
+ * SUBREDDIT - all
+ * COMMENTS_SUBREDDIT - all
+ * KAFKA_SERVER - localhost:9092
+
+
 ## Configuration
 
 [Docs](docs/source-connector-config.md)
@@ -73,6 +104,8 @@ kafka-topics --zookeeper localhost:2181 --create --topic reddit-posts --partitio
 # Run the connector
 connect-standalone config/connect-standalone.properties config/kafka-connect-reddit-source.properties
 ```
+
+  
 
 ## Offset Tracking
 
@@ -182,6 +215,7 @@ a PR without filing an issue first and tag @C0urante for review.
 - [x] Publish to [Confluent Hub]
 - [ ] Support reverse-chronological consumption
 - [ ] Sink connector
+- [ ] (In Docker) Replace variables in the prioperties files rather than append 
 
 PRs welcome and encouraged!
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ directory onto the plugin path or classpath for your Kafka Connect worker(s).
 To run this in standalone-mode via a docker container (this brings up the environment and the connector in a standalone worker):
 
 ```bash
-#Build the project 
+# Build the project 
 mvn clean package
 
 # Build the docker container 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ a PR without filing an issue first and tag @C0urante for review.
 - [x] Publish to [Confluent Hub]
 - [ ] Support reverse-chronological consumption
 - [ ] Sink connector
-- [ ] (In Docker) Replace variables in the prioperties files rather than append 
+- [ ] (In Docker) Replace variables in the properties files rather than append 
 
 PRs welcome and encouraged!
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ directory onto the plugin path or classpath for your Kafka Connect worker(s).
 
 ## Running standalone in docker
 
-To run this in standalone-mode via a docker container. (This brings up the environment + the connect-standalone):
+To run this in standalone-mode via a docker container (this brings up the environment and the connector in a standalone worker):
 
 ```bash
 #Build the project 

--- a/config/connect-standalone.properties
+++ b/config/connect-standalone.properties
@@ -8,3 +8,4 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 value.converter.schemas.enable=false
 
 plugin.path=target/components/packages/
+

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -2,7 +2,7 @@
 
 # We're going to override the subreddit, comments, and broker if we have an environment variable set
 
-[[ -v SUBREDDIT ]] && echo "posts.subreddits=$SUBREDDIT" >> /kafka-connect-reddit/kafka-connect-reddit-source.properties
+[[ -v SUBREDDIT ]] && sed -ir 's/^posts\.subreddits=.*$/posts.subreddits='"$SUBREDDIT/" kafka-connect-reddit.properties
 [[ -v COMMENTS_SUBREDDIT ]] && echo "comments.subreddits=$COMMENTS_SUBREDDIT" >> /kafka-connect-reddit/kafka-connect-reddit-source.properties
 [[ -v KAFKA_SERVER ]] && echo "bootstrap.servers=$KAFKA_SERVER" >> /kafka-connect-reddit/connect-standalone.properties
 

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# We're going to override the subreddit, comments, and broker if we have an environment variable set
+
+[[ -v SUBREDDIT ]] && echo "posts.subreddits=$SUBREDDIT" >> /kafka-connect-reddit/kafka-connect-reddit-source.properties
+[[ -v COMMENTS_SUBREDDIT ]] && echo "comments.subreddits=$COMMENTS_SUBREDDIT" >> /kafka-connect-reddit/kafka-connect-reddit-source.properties
+[[ -v KAFKA_SERVER ]] && echo "bootstrap.servers=$KAFKA_SERVER" >> /kafka-connect-reddit/connect-standalone.properties
+
+echo "plugin.path=/kafka-connect-reddit/install/" >> /kafka-connect-reddit/connect-standalone.properties
+
+/usr/bin/connect-standalone /kafka-connect-reddit/connect-standalone.properties /kafka-connect-reddit/kafka-connect-reddit-source.properties

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <properties>
         <jraw.version>1.1.0</jraw.version>
         <junit.version>4.12</junit.version>
-        <kafka.version>2.0.0</kafka.version>
-        <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
+        <kafka.version>2.4.1</kafka.version>
+        <kafka.connect.maven.plugin.version>0.11.2</kafka.connect.maven.plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
         <moshi.version>1.6.0</moshi.version>


### PR DESCRIPTION
This adds in support so that you can stand up this connector and have it up and working from a local build. Also, this gives support to customize the subreddit, comments subreddit, and broker via environment variable. 

Please note: the blank lines in `connect-standalone.properties` are neccessary because the environment variables are added to the property files and it's overriding the defaults from what you had. 