### PR TITLE
Add connector class and connection endpoint to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ directory onto the plugin path or classpath for your Kafka Connect worker(s).
 
 [Example](config/kafka-connect-reddit-source.properties)
 
+### Connector Class
+`com.github.c0urante.kafka.connect.reddit.RedditSourceConnector`
+
+### Connection Endpoints
+If you need to whitelist ingress/egress endpoints, include:
+
+`www.reddit.com:443`
+
 ## Quickstart
 
 Assumptions:


### PR DESCRIPTION
A new unannounced confluent offering will require the connector class and connection endpoints to be explicitly configured. The connection endpoint must be in the format documented but is not anywhere in this repo. Having the connector class available in the readme will be helpful as well so users won't have to go through the manifest to find it. 